### PR TITLE
Update `db_updated_at` to ISO 8601 format

### DIFF
--- a/.github/workflows/update_compat_db.yml
+++ b/.github/workflows/update_compat_db.yml
@@ -18,7 +18,7 @@ jobs:
         $compat_link = "https://api.github.com/repos/Vita3K/compatibility"
         $issues_link = $compat_link + "/issues"
         $app_updated = (Invoke-RestMethod -Uri $issues_link"?state=all&sort=updated" -Headers $headers)[0]
-        $db_updated_at = [DateTime]::Parse($app_updated.updated_at).ToUniversalTime().ToString("MM-dd-yyyy HH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture)
+        $db_updated_at = [DateTime]::Parse($app_updated.updated_at).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ssZ", [System.Globalization.CultureInfo]::InvariantCulture)
         $open_issues_count = (Invoke-RestMethod -Uri "$compat_link" -Headers $headers).open_issues_count
         $page_count = @()
         for ($i = 0; $i -lt $open_issues_count; $i += 100) {


### PR DESCRIPTION
This pull request includes a minor but important change to the date format in the `update_compat_db.yml` workflow file. The change ensures that the date format used is consistent with ISO 8601 standards.

* [`.github/workflows/update_compat_db.yml`](diffhunk://#diff-81b2c60c62eb6a90ffd62124e9a0709708ffaf8d5f1498c97edb9d8c21455fb8L21-R21): Updated the date format in the `db_updated_at` variable to use ISO 8601 format (`yyyy-MM-dd HH:mm:ssZ`) instead of the previous format (`MM-dd-yyyy HH:mm:ss`).